### PR TITLE
Created .gitignore with Github Python Template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,129 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/


### PR DESCRIPTION
As the commit message states, I am just simply adding a .gitignore with the python template.

this should stop IDE file/folder from appearing in the project. It should also stop the `__pycache__` directory from appearing anywhere. The pycache should not be committed at all.

Edit:

I noticed a few more things needed to be changed (not urgently ofc). I think these could improve code or project quality.
Add these at your own discretion or convenience.

## Things to improve this project. (In order of effort needed)

- having a requirements.txt with all the project dependencies
- Move main code into a new `src` directory. 
- Possible addition of a `Makefile`. I have one of these in any of my recent projects. (note: these may not work on Windows.)
- using the rply package in the lexer. [Example in my own project here](https://github.com/spidertyler2005/BCL/blob/master/src/Lexer.py) 
- sphinx documentation. This can be a game changer if you actually want people to use the project. They need a guide to be able to use it's features.

### sphinx documentation information

Sphinx docs are extremely useful. These are the docs you see on websites like `ReadTheDocs.io`. 

sphinx uses markdown files or reStructuredText to allow you to create great looking documentation. After a bit of practice, it's not too difficult.

**If you want help with this (understandably) then you can reach out to me for help**

### Why Modify folder structure and add "useless" files?

This is just for general organization and can make it easier for outsiders to understand the structure of your project *at-a-glance*.

Plus, files like `requirements.txt` allow people to install all libraries at once with a single command. This makes it much easier to contribute.

### Have a great day!